### PR TITLE
Allow smtp to endpoints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -605,6 +605,30 @@ resource "aws_security_group_rule" "endpoints_ingress_1" {
   security_group_id = aws_security_group.endpoints.id
 
 }
+resource "aws_security_group_rule" "endpoints_ingress_2" {
+  for_each = var.subnet_sets
+
+  description       = "Allow inbound SMTP"
+  type              = "ingress"
+  from_port         = 25
+  to_port           = 25
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.endpoints.id
+
+}
+resource "aws_security_group_rule" "endpoints_ingress_3" {
+  for_each = var.subnet_sets
+
+  description       = "Allow inbound HTTPS"
+  type              = "ingress"
+  from_port         = 587
+  to_port           = 587
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.endpoints.id
+
+}
 # SSM Endpoints
 resource "aws_vpc_endpoint" "ssm_interfaces" {
   for_each = toset(local.merged_endpoint_list)

--- a/main.tf
+++ b/main.tf
@@ -420,6 +420,7 @@ resource "aws_network_acl_rule" "allow_internet_egress_private_2" {
 }
 
 resource "aws_network_acl_rule" "allow_internet_ingress_private" {
+  #checkov:skip=CKV_AWS_231:"port 3389 included in range allowing inbound traffic"
   for_each = toset(local.distinct_subnets_by_key_type_private)
 
   network_acl_id = aws_network_acl.default[each.value].id

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = "~> 4.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
* Allow SMTP and SMTP-TLS to VPC Interface Endpoint security group
* Update required provider version to `~> 4.0` in line with other Modernisation Platform repositories