### PR TITLE
Set default route for non-public subnets to TGW

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,20 +81,6 @@ locals {
     if subnet.key != "transit-gateway"
   ])
 
-  # Distinct subnets by key type - Private
-  distinct_subnets_by_key_type_private = distinct([
-    for subnet in local.all_subnets_with_keys :
-    "${subnet.key}-${subnet.type}"
-    if subnet.type == "private"
-  ])
-
-  # Distinct subnets by key type - Public
-  distinct_subnets_by_key_type_public = distinct([
-    for subnet in local.all_subnets_with_keys :
-    "${subnet.key}-${subnet.type}"
-    if subnet.type == "public"
-  ])
-
   all_distinct_route_tables_with_keys = {
     for rt in local.all_distinct_route_tables :
     rt => rt

--- a/main.tf
+++ b/main.tf
@@ -303,6 +303,18 @@ resource "aws_route" "public_internet_gateway" {
   gateway_id             = aws_internet_gateway.default.id
 }
 
+resource "aws_route" "transit_gateway" {
+  for_each = {
+    for key, route_table in aws_route_table.route_tables :
+    key => route_table
+    if substr(key, length(key) - 6, length(key)) != "public"
+  }
+
+  route_table_id         = aws_route_table.route_tables[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
+}
+
 resource "aws_route_table" "protected" {
 
   vpc_id = aws_vpc.vpc.id

--- a/main.tf
+++ b/main.tf
@@ -74,13 +74,6 @@ locals {
     # local.expanded_protected_subnets_with_keys
   )
 
-  # Distinct subnets by key type not including Transit Gateway subnets
-  distinct_subnets_by_key_type = distinct([
-    for subnet in local.all_subnets_with_keys :
-    "${subnet.key}-${subnet.type}"
-    if subnet.key != "transit-gateway"
-  ])
-
   all_distinct_route_tables_with_keys = {
     for rt in local.all_distinct_route_tables :
     rt => rt

--- a/variables.tf
+++ b/variables.tf
@@ -22,18 +22,6 @@ variable "additional_endpoints" {
   type        = list(any)
 }
 
-variable "bastion_linux" {
-  description = ""
-  type        = bool
-  default     = false
-}
-
-variable "bastion_windows" {
-  description = ""
-  type        = bool
-  default     = false
-}
-
 variable "vpc_flow_log_iam_role" {
   description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 4.0"
       source  = "hashicorp/aws"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.4"
+    }
   }
   required_version = ">= 1.0.1"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "~> 3.4"
     }
   }


### PR DESCRIPTION
Given that our multi-VPC approach relies on the use of AWS Transit Gateway, when we create a member VPC with this code, we should route traffic for all subnets except private through the Transit Gateway