### PR TITLE
Allow use of redshift endpoints

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,8 @@ on:
       - '**.md'
       - '.github/workflows/documentation.yml'
 
+permissions: {}
+
 jobs:
   docs:
     permissions:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   docs:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ If you're looking to raise an issue with this module, please create a new issue 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4 |
 
 ## Modules

--- a/main.tf
+++ b/main.tf
@@ -363,6 +363,19 @@ resource "aws_security_group_rule" "endpoints_ingress_3" {
   security_group_id = aws_security_group.endpoints.id
 
 }
+
+resource "aws_security_group_rule" "endpoints_ingress_3" {
+  for_each = var.subnet_sets
+
+  description       = "Allow inbound Redshift"
+  type              = "ingress"
+  from_port         = 5439
+  to_port           = 5439
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.endpoints.id
+
+}
 # SSM Endpoints
 resource "aws_vpc_endpoint" "ssm_interfaces" {
   for_each = toset(local.merged_endpoint_list)


### PR DESCRIPTION
As part of [this story](https://github.com/ministryofjustice/modernisation-platform/issues/4538), this PR updates the VPC security group associated with VPC endpoints to allow redshift traffic in.