### PR TITLE
Add protected subnets to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "tgw_subnet_ids" {
 
 output "non_tgw_subnet_arns" {
   description = "Non-Transit Gateway and Protected subnet ARNs"
-  value = flatten(
+  value = concat(
     [ for key, subnet in aws_subnet.subnets : subnet.arn if substr(key, 0, 15) != "transit-gateway" ],
     [ for key, subnet in aws_subnet.protected : subnet.arn if substr(key, 0, 15) != "transit-gateway" ]
   )

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,12 +14,10 @@ output "tgw_subnet_ids" {
 
 output "non_tgw_subnet_arns" {
   description = "Non-Transit Gateway and Protected subnet ARNs"
-  value = [
-    for key, subnet in aws_subnet.subnets :
-    subnet.arn
-
-    if substr(key, 0, 15) != "transit-gateway"
-  ]
+  value = flatten(
+    [ for key, subnet in aws_subnet.subnets : subnet.arn if substr(key, 0, 15) != "transit-gateway" ],
+    [ for key, subnet in aws_subnet.protected : subnet.arn if substr(key, 0, 15) != "transit-gateway" ]
+  )
 }
 
 output "non_tgw_subnet_arns_by_set" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,8 +15,8 @@ output "tgw_subnet_ids" {
 output "non_tgw_subnet_arns" {
   description = "Non-Transit Gateway and Protected subnet ARNs"
   value = concat(
-    [ for key, subnet in aws_subnet.subnets : subnet.arn if substr(key, 0, 15) != "transit-gateway" ],
-    [ for key, subnet in aws_subnet.protected : subnet.arn if substr(key, 0, 15) != "transit-gateway" ]
+    [for key, subnet in aws_subnet.subnets : subnet.arn if substr(key, 0, 15) != "transit-gateway"],
+    [for key, subnet in aws_subnet.protected : subnet.arn if substr(key, 0, 15) != "transit-gateway"]
   )
 }
 
@@ -39,7 +39,7 @@ output "non_tgw_subnet_arns_by_subnetset" {
       "${key}-${cidr}" => aws_subnet.subnets["${subnet.key}-${subnet.type}-${subnet.az}"].arn
       if substr(subnet.key, 0, length(set)) == set
     }
-  },
+    },
     { "protected" = { for key, subnet in aws_subnet.protected : key => subnet.arn }
   })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,15 +32,16 @@ output "non_tgw_subnet_arns_by_set" {
 }
 
 output "non_tgw_subnet_arns_by_subnetset" {
-  value = {
+  value = merge({
     for set, cidr in var.subnet_sets : set =>
     {
       for key, subnet in local.expanded_worker_subnets_assocation :
       "${key}-${cidr}" => aws_subnet.subnets["${subnet.key}-${subnet.type}-${subnet.az}"].arn
       if substr(subnet.key, 0, length(set)) == set
-
     }
-  }
+  },
+    { "protected" = { for key, subnet in aws_subnet.protected : key => subnet.arn }
+  })
 }
 
 output "expanded_worker_subnets_assocation" {


### PR DESCRIPTION
This PR will create resource shares for the protected subnets. However, without these being accepted by member accounts, there will be no impact to member accounts.

This PR is a necessary part of resolving https://github.com/ministryofjustice/modernisation-platform/issues/4797, where a load balancer target group cannot attach the IP addresses of the `redshift-data` VPC endpoints as the protected subnets are not shared with the account and thus fail a validation check