### PR TITLE
Adds AWS Firehose and supporting resources.

### DIFF
--- a/firehose.tf
+++ b/firehose.tf
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
   count             = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name              = "${var.tags_prefix}-xsiam-delivery-group"
   tags              = try(var.tags_common, {})
-  retention_in_days = 366
+  retention_in_days = 400 # Because it's more than a year.
 }
 
 resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
@@ -307,7 +307,7 @@ resource "aws_s3_bucket_versioning" "xsiam_firehose_bucket_versioning" {
 
 # By default s3 already blocks public access but this added for the tfsec & checkov checks.
 resource "aws_s3_bucket_public_access_block" "xsiam_firehose_bucket_block_public" {
-  bucket = aws_s3_bucket.xsiam_firehose_bucket.id
+  bucket = aws_s3_bucket.xsiam_firehose_bucket[count.index].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,0 +1,251 @@
+
+
+# Sharing log data with SecOps via Firehose
+
+locals {
+
+}
+
+data "aws_secretsmanager_secret_version" "xsiam_network_secret" {
+  secret_id = "${var.secret_version_arn}"
+}
+
+resource "aws_flow_log" "firehose" {
+  iam_role_arn             = var.vpc_flow_log_iam_role
+  log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream.arn
+  max_aggregation_interval = "60"
+  traffic_type             = "ALL"
+  log_destination_type     = "kinesis-data-firehose"
+  vpc_id                   = aws_vpc.vpc.id
+
+  tags = merge(
+    var.tags_common,
+    {
+      Name = "${var.tags_prefix}-${var.environment}-vpc-flow-log-firehose-${random_id.flow_logs.hex}"
+    }
+  )
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
+  name        = "${var.tags_prefix}-${var.environment}-xsiam-delivery-stream"
+  destination = "http_endpoint"
+
+  tags = try(var.tags_common, {})
+
+  http_endpoint_configuration {
+    url                = var.endpoint_url
+    name               = "${var.tags_prefix}-${var.environment}-endpoint"
+    access_key         = data.aws_secretsmanager_secret_version.xsiam_network_secret.secret_string
+    buffering_size     = 5
+    buffering_interval = 300
+    role_arn           = aws_iam_role.xsiam_kinesis_firehose_role.arn
+    s3_backup_mode     = "FailedDataOnly"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.xsiam_delivery_group.name
+      log_stream_name = aws_cloudwatch_log_stream.xsiam_delivery_stream.name
+    }
+
+    s3_configuration {
+      role_arn           = aws_iam_role.xsiam_kinesis_firehose_role.arn
+      bucket_arn         = aws_s3_bucket.xsiam_firehose_bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
+
+    request_configuration {
+      content_encoding = "GZIP"
+
+      common_attributes {
+        name  = "business_area"
+        value = var.tags_prefix
+      }
+    }
+
+  }
+}
+
+resource "aws_s3_bucket" "xsiam_firehose_bucket" {
+  bucket = "${var.tags_prefix}-${var.environment}-xsiam-firehose-bucket"
+   tags  = try(var.tags_common,{})
+}
+
+resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
+  name              = "${var.tags_prefix}-${var.environment}-xsiam-delivery-group"
+  tags              = try(var.tags_common,{})
+  retention_in_days = 90
+}
+
+resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
+  name           = "${var.tags_prefix}-${var.environment}-errors"
+  log_group_name = aws_cloudwatch_log_group.xsiam_delivery_group.name
+}
+
+resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
+
+  name = "${var.tags_prefix}-xsiam-delivery-stream-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "firehose.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = try(var.tags_common,{})
+}
+
+resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
+  role = aws_iam_role.xsiam_kinesis_firehose_role.id
+
+  name = "${var.tags_prefix}-xsiam_kinesis_firehose_role_policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "log-access"
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "secretsmanager"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+        Resource = "${var.secret_version_arn}"
+      }
+    ]
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attachment" {
+  policy_arn = aws_iam_policy.xsiam_kinesis_firehose_error_log_policy.arn
+  role       = aws_iam_role.xsiam_kinesis_firehose_role.name
+
+}
+
+resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
+  name = "${var.tags_prefix}-xsiam_kinesis_firehose_error_log_policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:PutLogEvents",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${aws_cloudwatch_log_group.xsiam_delivery_group.arn}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = try(var.tags_common,{})
+}
+
+resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
+  policy_arn = aws_iam_policy.s3_kinesis_xsiam_policy.arn
+  role       = aws_iam_role.xsiam_kinesis_firehose_role.name
+
+}
+
+resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  name = "${var.tags_prefix}-s3_kinesis_xsiam_policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:PutObject"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_s3_bucket.xsiam_firehose_bucket.arn,
+          "${aws_s3_bucket.xsiam_firehose_bucket.arn}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = try(var.tags_common,{})
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscription" {
+  name            = "${var.tags_prefix}-nacs_server_xsiam_subscription"
+  role_arn        = aws_iam_role.this.arn
+  log_group_name  = aws_flow_log.cloudwatch.log_group_name
+  filter_pattern  = ""
+  destination_arn = aws_kinesis_firehose_delivery_stream.firehose_stream.arn
+}
+
+resource "aws_iam_role" "put_record_role" {
+  name_prefix        = "${var.tags_prefix}-put_record_role"
+  tags               = try(var.tags_common,{})
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "logs.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "put_record_policy" {
+  name_prefix = "${var.tags_prefix}-put_record_policy"
+  tags        = try(var.tags_common,{})
+  policy      = <<-EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "firehose:PutRecord",
+                "firehose:PutRecordBatch"
+            ],
+            "Resource": [
+                "${aws_kinesis_firehose_delivery_stream.firehose_stream.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
+  role       = aws_iam_role.put_record_role.arn
+  policy_arn = aws_iam_policy.put_record_policy.arn
+}

--- a/firehose.tf
+++ b/firehose.tf
@@ -90,7 +90,7 @@ resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
   tags = try(var.tags_common, {})
 }
 
-#tfsec:ignore:aws-iam-no-policy-wildcards - We are keeping this 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
   #checkov:skip=CKV_AWS_355: - Ignore for now whilst we look into this.
   count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0

--- a/firehose.tf
+++ b/firehose.tf
@@ -121,6 +121,7 @@ resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attac
 
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
   count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-xsiam-kinesis-firehose-error-log-policy"

--- a/firehose.tf
+++ b/firehose.tf
@@ -264,7 +264,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
   count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
-  role       = aws_iam_role.put_record_role[count.index].arn
+  role       = aws_iam_role.put_record_role[count.index].name
   policy_arn = aws_iam_policy.put_record_policy[count.index].arn
 }
 

--- a/firehose.tf
+++ b/firehose.tf
@@ -169,7 +169,7 @@ resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
         ]
         Effect = "Allow"
         Resource = [
-          "${aws_s3_bucket.xsiam_firehose_bucket[count.index].arn}",
+          aws_s3_bucket.xsiam_firehose_bucket[count.index].arn,
           "${aws_s3_bucket.xsiam_firehose_bucket[count.index].arn}/*"
         ]
       }
@@ -242,13 +242,15 @@ resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
 }
 
 
-# S3 Bucket to hold the transfer failure logs. We are using the default s3 key and no logging as it is not needed.
+# S3 Bucket to hold the transfer failure logs. We are using the default s3 key and no logging as it is not needed. We also have public access blocked by default
 
 #tfsec:ignore:aws-ssm-secret-use-customer-key
 #tfsec:ignore:aws-s3-encryption-customer-key
-#tfsec:ignore:aws-s3-enable-bucket-logging 
+#tfsec:ignore:aws-s3-enable-bucket-logging
+#tfsec:ignore:aws-s3-specify-public-access-block
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
   #checkov:skip=CKV_AWS_241: We have encryption already in place using the default s3 kms key.
+  #checkov:skip=CKV_AWS_21: We already have versioning enabled.
   #checkov:skip=CKV_AWS_145: We use the default encryption key.
   #checkov:skip=CKV2_AWS_62: We do not need event notifications enabled.
   #checkov:skip=CKV_AWS_144: We are not using cross-region replication.

--- a/firehose.tf
+++ b/firehose.tf
@@ -17,6 +17,10 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 
   tags = try(var.tags_common, {})
 
+  server_side_encryption {
+    enabled = true    
+  }
+
   http_endpoint_configuration {
     url                = var.kinesis_endpoint_url
     name               = "${var.tags_prefix}-endpoint"
@@ -235,7 +239,10 @@ resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
 }
 
 
+# S3 Bucket to hold the transfer failure logs
+
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
+  #checkov:skip=CKV_AWS_241: We have encryption already in place using the default s3 kms key.
   count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   bucket = "${var.tags_prefix}-xsiam-firehose-bucket"
   tags   = try(var.tags_common, {})

--- a/firehose.tf
+++ b/firehose.tf
@@ -248,6 +248,10 @@ resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
 #tfsec:ignore:aws-s3-encryption-customer-key
 #tfsec:ignore:aws-s3-enable-bucket-logging
 #tfsec:ignore:aws-s3-specify-public-access-block
+#tfsec:ignore:aws-s3-block-public-acls
+#tfsec:ignore:aws-s3-block-public-policy
+#tfsec:ignore:aws-s3-no-public-buckets
+#tfsec:ignore:aws-s3-ignore-public-acls
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
   #checkov:skip=CKV_AWS_241: We have encryption already in place using the default s3 kms key.
   #checkov:skip=CKV_AWS_21: We already have versioning enabled.

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,7 +1,6 @@
 
-
-# Sharing log data with SecOps via Firehose
-
+# Sharing log data with SecOps via Firehose.check "name"
+# Note that var.tags_prefix includes the environment name so we don't need to include that in the name as a separate variable.
 
 resource "aws_flow_log" "firehose" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
@@ -15,7 +14,7 @@ resource "aws_flow_log" "firehose" {
   tags = merge(
     var.tags_common,
     {
-      Name = "${var.tags_prefix}-${var.environment}-vpc-flow-log-firehose-${random_id.flow_logs.hex}"
+      Name = "${var.tags_prefix}-vpc-flow-log-firehose-${random_id.flow_logs.hex}"
     }
   )
 }
@@ -23,14 +22,14 @@ resource "aws_flow_log" "firehose" {
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
 
-  name        = "${var.tags_prefix}-${var.environment}-xsiam-delivery-stream"
+  name        = "${var.tags_prefix}-xsiam-delivery-stream"
   destination = "http_endpoint"
 
   tags = try(var.tags_common, {})
 
   http_endpoint_configuration {
     url                = var.endpoint_url
-    name               = "${var.tags_prefix}-${var.environment}-endpoint"
+    name               = "${var.tags_prefix}-endpoint"
     access_key         = var.secret_string
     buffering_size     = 5
     buffering_interval = 300
@@ -65,20 +64,20 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  bucket = "${var.tags_prefix}-${var.environment}-xsiam-firehose-bucket"
+  bucket = "${var.tags_prefix}-xsiam-firehose-bucket"
    tags  = try(var.tags_common,{})
 }
 
 resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  name              = "${var.tags_prefix}-${var.environment}-xsiam-delivery-group"
+  name              = "${var.tags_prefix}-xsiam-delivery-group"
   tags              = try(var.tags_common,{})
   retention_in_days = 90
 }
 
 resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  name           = "${var.tags_prefix}-${var.environment}-errors"
+  name           = "${var.tags_prefix}-errors"
   log_group_name = aws_cloudwatch_log_group.xsiam_delivery_group[count.index].name
 }
 

--- a/firehose.tf
+++ b/firehose.tf
@@ -242,7 +242,8 @@ resource "aws_s3_bucket" "xsiam_firehose_bucket" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "xsiam_firehose_bucket_encryption" {
-  bucket = aws_s3_bucket.xsiam_firehose_bucket.id
+  count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.xsiam_firehose_bucket[count.index].id
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "aws:kms"
@@ -251,7 +252,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "xsiam_firehose_bu
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "xsiam_firehose_bucket_config" {
-  bucket = aws_s3_bucket.xsiam_firehose_bucket.id
+  count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.xsiam_firehose_bucket[count.index].id
   rule {
     id = "delete-old"
     expiration {
@@ -266,7 +268,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "xsiam_firehose_bucket_config" 
 }
 
 resource "aws_s3_bucket_versioning" "xsiam_firehose_bucket_versioning" {
-  bucket = aws_s3_bucket.xsiam_firehose_bucket.id
+  count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.xsiam_firehose_bucket[count.index].id
   versioning_configuration {
     status = "Enabled"
   }

--- a/firehose.tf
+++ b/firehose.tf
@@ -307,6 +307,7 @@ resource "aws_s3_bucket_versioning" "xsiam_firehose_bucket_versioning" {
 
 # By default s3 already blocks public access but this added for the tfsec & checkov checks.
 resource "aws_s3_bucket_public_access_block" "xsiam_firehose_bucket_block_public" {
+  count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   bucket = aws_s3_bucket.xsiam_firehose_bucket[count.index].id
   block_public_acls       = true
   block_public_policy     = true

--- a/firehose.tf
+++ b/firehose.tf
@@ -2,13 +2,6 @@
 
 # Sharing log data with SecOps via Firehose
 
-locals {
-
-}
-
-data "aws_secretsmanager_secret_version" "xsiam_network_secret" {
-  secret_id = "${var.secret_version_arn}"
-}
 
 resource "aws_flow_log" "firehose" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,5 +1,5 @@
 
-# Sharing log data with SecOps via Firehose.check "name".check "name"
+# Sharing log data with SecOps via AWS Firehose & a subscription on the cloudwatch log that contains flow log data.
 
 # To build the firehose resources we want the following to be true:
 # - var.build_firehose is true
@@ -7,34 +7,6 @@
 # This ensures that we don't try and build the resources without an endpoint provided.
 
 # Note that var.tags_prefix includes the environment name so we don't need to include that in the name as a separate variable.
-
-
-
-# resource "aws_cloudwatch_log_destination" "kinesis_endpoint_destination" {
-#   name       = "${var.tags_prefix}-kinesis_endpoint_destination-destination"
-#   role_arn   = aws_iam_role.iam_for_cloudwatch.arn # needs to be a secret
-#   target_arn = aws_kinesis_stream.kinesis_for_cloudwatch.arn # arn of the endpoint?
-# }
-
-# We don't need a new flow log as we have a subscription to the existing log. This is only needed if we are transfering data to a firehose stream in another account.
-
-# resource "aws_flow_log" "firehose" {
-#   count                    = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 # Builds the resource if this var is true, else do nothing.
-#   iam_role_arn             = var.vpc_flow_log_iam_role
-#   log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream[count.index].arn
-#   max_aggregation_interval = "60"
-#   traffic_type             = "ALL"
-#   log_destination_type     = "kinesis-data-firehose"
-#   vpc_id                   = aws_vpc.vpc.id
-
-#   tags = merge(
-#     var.tags_common,
-#     {
-#       Name = "${var.tags_prefix}-vpc-flow-log-firehose-${random_id.flow_logs.hex}"
-#     }
-#   )
-# }
-
 
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {

--- a/firehose.tf
+++ b/firehose.tf
@@ -6,7 +6,7 @@
 resource "aws_flow_log" "firehose" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   iam_role_arn             = var.vpc_flow_log_iam_role
-  log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream.arn
+  log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream[count.index].arn
   max_aggregation_interval = "60"
   traffic_type             = "ALL"
   log_destination_type     = "kinesis-data-firehose"
@@ -144,7 +144,7 @@ resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
         ]
         Effect = "Allow"
         Resource = [
-          "${aws_cloudwatch_log_group.xsiam_delivery_group.arn}/*"
+          "${aws_cloudwatch_log_group.xsiam_delivery_group[count.index].arn}/*"
         ]
       }
     ]
@@ -192,7 +192,7 @@ resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
 resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscription" {
   count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name            = "${var.tags_prefix}-nacs_server_xsiam_subscription"
-  role_arn        = aws_iam_role.this.arn
+  role_arn        = aws_iam_role.put_record_role[count.index].arn
   log_group_name  = aws_flow_log.cloudwatch.log_group_name
   filter_pattern  = ""
   destination_arn = aws_kinesis_firehose_delivery_stream.firehose_stream[count.index].arn

--- a/firehose.tf
+++ b/firehose.tf
@@ -38,7 +38,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
   http_endpoint_configuration {
     url                = var.endpoint_url
     name               = "${var.tags_prefix}-${var.environment}-endpoint"
-    access_key         = data.aws_secretsmanager_secret_version.xsiam_network_secret.secret_string
+    access_key         = var.secret_string
     buffering_size     = 5
     buffering_interval = 300
     role_arn           = aws_iam_role.xsiam_kinesis_firehose_role.arn
@@ -126,16 +126,6 @@ resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
           "logs:GetLogEvents"
         ]
         Resource = "*"
-      },
-      {
-        Sid    = "secretsmanager"
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue",
-          "secretsmanager:DescribeSecret",
-          "secretsmanager:ListSecretVersionIds"
-        ]
-        Resource = "${var.secret_version_arn}"
       }
     ]
     }

--- a/firehose.tf
+++ b/firehose.tf
@@ -28,9 +28,9 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
   tags = try(var.tags_common, {})
 
   http_endpoint_configuration {
-    url                = var.endpoint_url
+    url                = var.kinesis_endpoint_url
     name               = "${var.tags_prefix}-endpoint"
-    access_key         = var.secret_string
+    access_key         = var.kinesis_endpoint_secret_string
     buffering_size     = 5
     buffering_interval = 300
     role_arn           = aws_iam_role.xsiam_kinesis_firehose_role[count.index].arn

--- a/firehose.tf
+++ b/firehose.tf
@@ -26,7 +26,7 @@ resource "aws_flow_log" "firehose" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
 
   name        = "${var.tags_prefix}-xsiam-delivery-stream"
   destination = "http_endpoint"
@@ -69,26 +69,26 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 }
 
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count  = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   bucket = "${var.tags_prefix}-xsiam-firehose-bucket"
   tags   = try(var.tags_common, {})
 }
 
 resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
-  count             = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count             = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name              = "${var.tags_prefix}-xsiam-delivery-group"
   tags              = try(var.tags_common, {})
   retention_in_days = 90
 }
 
 resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
-  count          = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count          = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name           = "${var.tags_prefix}-errors"
   log_group_name = aws_cloudwatch_log_group.xsiam_delivery_group[count.index].name
 }
 
 resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-xsiam-delivery-stream-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -131,14 +131,14 @@ resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attachment" {
-  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   policy_arn = aws_iam_policy.xsiam_kinesis_firehose_error_log_policy[count.index].arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role[count.index].name
 
 }
 
 resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-xsiam_kinesis_firehose_error_log_policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -159,7 +159,7 @@ resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
-  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   policy_arn = aws_iam_policy.s3_kinesis_xsiam_policy[count.index].arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role[count.index].name
 
@@ -168,7 +168,7 @@ resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
 resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax. 
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-s3_kinesis_xsiam_policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -195,7 +195,7 @@ resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscription" {
-  count           = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count           = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name            = "${var.tags_prefix}-nacs_server_xsiam_subscription"
   role_arn        = aws_iam_role.put_record_role[count.index].arn
   log_group_name  = aws_flow_log.cloudwatch.log_group_name
@@ -204,7 +204,7 @@ resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscriptio
 }
 
 resource "aws_iam_role" "put_record_role" {
-  count              = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count              = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name_prefix        = "${var.tags_prefix}-put_record_role"
   tags               = try(var.tags_common, {})
   assume_role_policy = <<EOF
@@ -225,7 +225,7 @@ EOF
 }
 
 resource "aws_iam_policy" "put_record_policy" {
-  count       = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count       = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name_prefix = "${var.tags_prefix}-put_record_policy"
   tags        = try(var.tags_common, {})
   policy      = <<-EOF
@@ -248,7 +248,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
-  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count      = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   role       = aws_iam_role.put_record_role[count.index].arn
   policy_arn = aws_iam_policy.put_record_policy[count.index].arn
 }

--- a/firehose.tf
+++ b/firehose.tf
@@ -3,7 +3,7 @@
 # Note that var.tags_prefix includes the environment name so we don't need to include that in the name as a separate variable.
 
 resource "aws_flow_log" "firehose" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count                    = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   iam_role_arn             = var.vpc_flow_log_iam_role
   log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream[count.index].arn
   max_aggregation_interval = "60"
@@ -20,7 +20,7 @@ resource "aws_flow_log" "firehose" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
 
   name        = "${var.tags_prefix}-xsiam-delivery-stream"
   destination = "http_endpoint"
@@ -63,27 +63,27 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 }
 
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count  = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   bucket = "${var.tags_prefix}-xsiam-firehose-bucket"
-   tags  = try(var.tags_common,{})
+  tags   = try(var.tags_common, {})
 }
 
 resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count             = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   name              = "${var.tags_prefix}-xsiam-delivery-group"
-  tags              = try(var.tags_common,{})
+  tags              = try(var.tags_common, {})
   retention_in_days = 90
 }
 
 resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count          = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   name           = "${var.tags_prefix}-errors"
   log_group_name = aws_cloudwatch_log_group.xsiam_delivery_group[count.index].name
 }
 
 resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  name = "${var.tags_prefix}-xsiam-delivery-stream-role"
+  count = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
+  name  = "${var.tags_prefix}-xsiam-delivery-stream-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -97,12 +97,12 @@ resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
     ]
   })
 
-  tags = try(var.tags_common,{})
+  tags = try(var.tags_common, {})
 }
 
 resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
- 
+  count = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing. 
+
   role = aws_iam_role.xsiam_kinesis_firehose_role[count.index].id
 
   name = "${var.tags_prefix}-xsiam_kinesis_firehose_role_policy"
@@ -125,15 +125,15 @@ resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attachment" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count      = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   policy_arn = aws_iam_policy.xsiam_kinesis_firehose_error_log_policy[count.index].arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role[count.index].name
 
 }
 
 resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  name = "${var.tags_prefix}-xsiam_kinesis_firehose_error_log_policy"
+  count = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
+  name  = "${var.tags_prefix}-xsiam_kinesis_firehose_error_log_policy"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -149,11 +149,11 @@ resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
     ]
   })
 
-  tags = try(var.tags_common,{})
+  tags = try(var.tags_common, {})
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
+  count      = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing. 
   policy_arn = aws_iam_policy.s3_kinesis_xsiam_policy[count.index].arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role[count.index].name
 
@@ -162,8 +162,8 @@ resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
 resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax. 
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
-  name = "${var.tags_prefix}-s3_kinesis_xsiam_policy"
+  count = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
+  name  = "${var.tags_prefix}-s3_kinesis_xsiam_policy"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -185,11 +185,11 @@ resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
     ]
   })
 
-  tags = try(var.tags_common,{})
+  tags = try(var.tags_common, {})
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscription" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count           = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   name            = "${var.tags_prefix}-nacs_server_xsiam_subscription"
   role_arn        = aws_iam_role.put_record_role[count.index].arn
   log_group_name  = aws_flow_log.cloudwatch.log_group_name
@@ -198,9 +198,9 @@ resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscriptio
 }
 
 resource "aws_iam_role" "put_record_role" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count              = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   name_prefix        = "${var.tags_prefix}-put_record_role"
-  tags               = try(var.tags_common,{})
+  tags               = try(var.tags_common, {})
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -219,9 +219,9 @@ EOF
 }
 
 resource "aws_iam_policy" "put_record_policy" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
+  count       = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing. 
   name_prefix = "${var.tags_prefix}-put_record_policy"
-  tags        = try(var.tags_common,{})
+  tags        = try(var.tags_common, {})
   policy      = <<-EOF
 {
     "Version": "2012-10-17",
@@ -242,7 +242,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
-  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+  count      = var.build_firehose ? 1 : 0 # Builds the resource if this var is true, else do nothing.
   role       = aws_iam_role.put_record_role[count.index].arn
   policy_arn = aws_iam_policy.put_record_policy[count.index].arn
 }

--- a/firehose.tf
+++ b/firehose.tf
@@ -150,7 +150,7 @@ resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attac
 }
 
 resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-xsiam-kinesis-firehose-error-log-policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -180,7 +180,7 @@ resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
 resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax. 
-  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name  = "${var.tags_prefix}-s3-kinesis-xsiam-policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -219,7 +219,7 @@ resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscriptio
 }
 
 resource "aws_iam_role" "put_record_role" {
-  count              = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count              = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name_prefix        = "${var.tags_prefix}-put-record-role"
   tags               = try(var.tags_common, {})
   assume_role_policy = <<EOF
@@ -240,7 +240,7 @@ EOF
 }
 
 resource "aws_iam_policy" "put_record_policy" {
-  count       = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0 
+  count       = var.build_firehose && length(var.kinesis_endpoint_url) > 0 ? 1 : 0
   name_prefix = "${var.tags_prefix}-put-record-policy"
   tags        = try(var.tags_common, {})
   policy      = <<-EOF

--- a/firehose.tf
+++ b/firehose.tf
@@ -11,6 +11,7 @@ data "aws_secretsmanager_secret_version" "xsiam_network_secret" {
 }
 
 resource "aws_flow_log" "firehose" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   iam_role_arn             = var.vpc_flow_log_iam_role
   log_destination          = aws_kinesis_firehose_delivery_stream.firehose_stream.arn
   max_aggregation_interval = "60"
@@ -27,6 +28,8 @@ resource "aws_flow_log" "firehose" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
+
   name        = "${var.tags_prefix}-${var.environment}-xsiam-delivery-stream"
   destination = "http_endpoint"
 
@@ -68,23 +71,26 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_stream" {
 }
 
 resource "aws_s3_bucket" "xsiam_firehose_bucket" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   bucket = "${var.tags_prefix}-${var.environment}-xsiam-firehose-bucket"
    tags  = try(var.tags_common,{})
 }
 
 resource "aws_cloudwatch_log_group" "xsiam_delivery_group" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name              = "${var.tags_prefix}-${var.environment}-xsiam-delivery-group"
   tags              = try(var.tags_common,{})
   retention_in_days = 90
 }
 
 resource "aws_cloudwatch_log_stream" "xsiam_delivery_stream" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name           = "${var.tags_prefix}-${var.environment}-errors"
   log_group_name = aws_cloudwatch_log_group.xsiam_delivery_group.name
 }
 
 resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
-
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name = "${var.tags_prefix}-xsiam-delivery-stream-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -103,6 +109,8 @@ resource "aws_iam_role" "xsiam_kinesis_firehose_role" {
 }
 
 resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
+ 
   role = aws_iam_role.xsiam_kinesis_firehose_role.id
 
   name = "${var.tags_prefix}-xsiam_kinesis_firehose_role_policy"
@@ -135,12 +143,14 @@ resource "aws_iam_role_policy" "xsiam_kinesis_firehose_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_firehose_error_log_role_attachment" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   policy_arn = aws_iam_policy.xsiam_kinesis_firehose_error_log_policy.arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role.name
 
 }
 
 resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name = "${var.tags_prefix}-xsiam_kinesis_firehose_error_log_policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -161,15 +171,16 @@ resource "aws_iam_policy" "xsiam_kinesis_firehose_error_log_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "kinesis_role_attachment" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
   policy_arn = aws_iam_policy.s3_kinesis_xsiam_policy.arn
   role       = aws_iam_role.xsiam_kinesis_firehose_role.name
 
 }
 
 resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
-
   # Terraform's "jsonencode" function converts a
-  # Terraform expression result to valid JSON syntax.
+  # Terraform expression result to valid JSON syntax. 
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name = "${var.tags_prefix}-s3_kinesis_xsiam_policy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -196,6 +207,7 @@ resource "aws_iam_policy" "s3_kinesis_xsiam_policy" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscription" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name            = "${var.tags_prefix}-nacs_server_xsiam_subscription"
   role_arn        = aws_iam_role.this.arn
   log_group_name  = aws_flow_log.cloudwatch.log_group_name
@@ -204,6 +216,7 @@ resource "aws_cloudwatch_log_subscription_filter" "nacs_server_xsiam_subscriptio
 }
 
 resource "aws_iam_role" "put_record_role" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   name_prefix        = "${var.tags_prefix}-put_record_role"
   tags               = try(var.tags_common,{})
   assume_role_policy = <<EOF
@@ -224,6 +237,7 @@ EOF
 }
 
 resource "aws_iam_policy" "put_record_policy" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing. 
   name_prefix = "${var.tags_prefix}-put_record_policy"
   tags        = try(var.tags_common,{})
   policy      = <<-EOF
@@ -246,6 +260,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "put_record_policy_attachment" {
+  count = var.build_firehose ? 1 : 0  # Builds the resource if this var is true, else do nothing.
   role       = aws_iam_role.put_record_role.arn
   policy_arn = aws_iam_policy.put_record_policy.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,22 +41,3 @@ variable "kinesis_endpoint_secret_string" {
   description = "The secret that contains the endpoint key"
   type        = string
 }
-variable "build_firehose" {
-  description = "boolean for whether AWS Firehose resources are built in the environment"
-  type        = bool
-}
-
-variable "environment" {
-  description = "The name of the environment e.g. development, test etc"
-  type        = string
-}
-
-variable "endpoint_url" {
-  description = "The aws kenisis http endpoint that the log data will be sent to"
-  type        = string
-}
-
-variable "secret_string" {
-  description = "The secret that contains the endpoint key"
-  type        = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -32,17 +32,12 @@ variable "build_firehose" {
   type        = bool
 }
 
-variable "environment" {
-  description = "The name of the environment e.g. development, test etc"
+variable "kinesis_endpoint_url" {
+  description = "The aws kinesis http endpoint that the log data will be sent to"
   type        = string
 }
 
-variable "endpoint_url" {
-  description = "The aws kenisis http endpoint that the log data will be sent to"
-  type        = string
-}
-
-variable "secret_string" {
+variable "kinesis_endpoint_secret_string" {
   description = "The secret that contains the endpoint key"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "endpoint_url" {
   type        = string
 }
 
-variable "secret_version_arn" {
-  description = "The arn of the secret version that contains the endpoint key"
+variable "secret_string" {
+  description = "The secret that contains the endpoint key"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "vpc_flow_log_iam_role" {
   type        = string
 }
 
+variable "build_firehose" {
+  description = "boolean for whether AWS Firehose resources are built in the environment"
+  type        = bool
+}
+
 variable "environment" {
   description = "The name of the environment e.g. development, test etc"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,22 @@ variable "kinesis_endpoint_secret_string" {
   description = "The secret that contains the endpoint key"
   type        = string
 }
+variable "build_firehose" {
+  description = "boolean for whether AWS Firehose resources are built in the environment"
+  type        = bool
+}
+
+variable "environment" {
+  description = "The name of the environment e.g. development, test etc"
+  type        = string
+}
+
+variable "endpoint_url" {
+  description = "The aws kenisis http endpoint that the log data will be sent to"
+  type        = string
+}
+
+variable "secret_string" {
+  description = "The secret that contains the endpoint key"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,18 @@ variable "vpc_flow_log_iam_role" {
   description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
   type        = string
 }
+
+variable "environment" {
+  description = "The name of the environment e.g. development, test etc"
+  type        = string
+}
+
+variable "endpoint_url" {
+  description = "The aws kenisis http endpoint that the log data will be sent to"
+  type        = string
+}
+
+variable "secret_version_arn" {
+  description = "The arn of the secret version that contains the endpoint key"
+  type        = string
+}


### PR DESCRIPTION
As part of ticket 6163 (https://github.com/ministryofjustice/modernisation-platform/issues/6163) this PR adds the following resources to this module:
- AWS Firehose that sends flow-log data in cloudwatch logs to a http endpoint.
- S3 bucket to capture transfer failures
- Subscription for the cloudwatch log that transfers the data to firehose.
- Other resources required (e.g. IAM etc) to support the operation of the above.