### PR TITLE
Added output for VPC flow log group name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -75,3 +75,7 @@ output "private_route_tables" {
     if substr(key, length(key) - 6, length(key)) != "public"
   }
 }
+
+output "vpc_flow_log" {
+  value = aws_cloudwatch_log_group.default.name
+}


### PR DESCRIPTION
As part of [#7607](https://github.com/ministryofjustice/modernisation-platform/issues/7607), we need to output the CloudWatch log group name for the VPC flow logs.

This PR adds a simple output so that the name can be used to populate an `aws_cloudwatch_log_subscription_filter` resource.