### PR TITLE
Optionally send flow logs to S3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,10 @@ locals {
     var.additional_endpoints
   )
 
+  # Custom VPC flow log statement
+  custom_flow_log_format = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${vpc-id} $${subnet-id} $${instance-id} $${tcp-flags} $${type} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${az-id} $${sublocation-type} $${sublocation-id} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
+
+
 }
 
 # VPC
@@ -191,6 +195,23 @@ resource "aws_flow_log" "cloudwatch" {
     var.tags_common,
     {
       Name = "${var.tags_prefix}-vpc-flow-logs-${random_id.flow_logs.hex}"
+    }
+  )
+}
+
+resource "aws_flow_log" "s3" {
+  for_each                 = var.flow_log_s3_destination_arn != "" ? toset([var.flow_log_s3_destination_arn]) : toset([])
+  log_destination          = each.key
+  log_destination_type     = "s3"
+  log_format               = local.custom_flow_log_format
+  max_aggregation_interval = "60"
+  traffic_type             = "ALL"
+  vpc_id                   = aws_vpc.vpc.id
+
+  tags = merge(
+    var.tags_common,
+    {
+      Name = "${var.tags_prefix}-vpc-flow-logs-s3-${random_id.flow_logs.hex}"
     }
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "build_firehose" {
 }
 
 variable "flow_log_s3_destination_arn" {
-  description = ""
+  description = "Optionally supply an ARN of an S3 bucket to send flow logs to"
   default     = ""
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,19 @@
+variable "additional_endpoints" {
+  description = "additional endpoints required for VPC"
+  type        = list(any)
+}
+
+variable "build_firehose" {
+  description = "Whether we want to build the firehose resources in the environment or not"
+  type        = bool
+}
+
+variable "flow_log_s3_destination_arn" {
+  description = ""
+  default     = ""
+  type        = string
+}
+
 variable "subnet_sets" {
   type = map(any)
 }
@@ -17,20 +33,9 @@ variable "transit_gateway_id" {
   type        = string
 }
 
-variable "additional_endpoints" {
-  description = "additional endpoints required for VPC"
-  type        = list(any)
-}
-
 variable "vpc_flow_log_iam_role" {
   description = "VPC Flow Log IAM role ARN for VPC Flow Logs to CloudWatch"
   type        = string
-}
-
-
-variable "build_firehose" {
-  description = "Whether we want to build the firehose resources in the environment or not"
-  type        = bool
 }
 
 # Both of the following variables are required for the firehose resources to build.


### PR DESCRIPTION
As part of [#7607](https://github.com/ministryofjustice/modernisation-platform/issues/7607) we've decided to stream vpc flow logs from interesting VPCs directly to S3.

This PR allows us to optionally create a VPC flow log that outputs to S3.

For example, to create flow logs that output to S3 only in production:
```
module "vpc" {
  source = "github.com/ministryofjustice/modernisation-platform-terraform-member-vpc"
  ...
  flow_log_s3_destination_arn = local.is-production ? local.cloudwatch_log_buckets["vpc-flow-logs"] : ""
}
```
