### PR TITLE
Amend cloudwatch VPC flow logs to include all available fields

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,9 +189,10 @@ resource "aws_cloudwatch_log_group" "default" {
 resource "aws_flow_log" "cloudwatch" {
   iam_role_arn             = var.vpc_flow_log_iam_role
   log_destination          = aws_cloudwatch_log_group.default.arn
+  log_destination_type     = "cloud-watch-logs"
+  log_format               = local.custom_flow_log_format
   max_aggregation_interval = "60"
   traffic_type             = "ALL"
-  log_destination_type     = "cloud-watch-logs"
   vpc_id                   = aws_vpc.vpc.id
 
   tags = merge(


### PR DESCRIPTION
As part of [this Slack conversation](https://mojdt.slack.com/archives/C6D94J81E/p1733228097115609) we've encountered a need for more detail in our CloudWatch VPC Flow Logs. This PR will use the same custom format that's used for XSIAM to include all available flow log fields.