### PR TITLE
Update to v6 aws provider

### DIFF
--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = "~> 5.0"
+      version               = "~> 6.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.transit-gateway-host]
     }
@@ -10,5 +10,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
This PR bumps the module to the latest v6 AWS Terraform provider