### PR TITLE
Updates Terraform version requirement from ~> 1.0 to ~> 1.10

### DIFF
--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.3"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,5 +10,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }


### PR DESCRIPTION
**Summary**
Updates Terraform version requirement from `~> 1.0` to `~> 1.10` to support the `cidrcontains` function used in secondary CIDR block validation.

**Changes**
- Updated `required_version` in `versions.tf` from `"~> 1.0"` to `"~> 1.10"`

**Context**
The secondary CIDR blocks feature (v5.1.0) uses the `cidrcontains()` function for overlap detection, which was introduced in Terraform 1.8. Setting the minimum to 1.10 ensures compatibility and aligns with current Terraform releases.